### PR TITLE
Promote to master (#78)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM base as build
 COPY ./package*.js* /opt/app-root/src/
 RUN npm set progress=false && \
   npm config set depth 0 && \
-  npm install
+  npm ci --only-production --ignore-scripts
 
 COPY ./config /opt/app-root/src/config
 COPY ./public /opt/app-root/src/public

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   },
   "lint-staged": {
     "./**/*.{js,scss,html,png,yaml,yml}": [
-      "npm run build",
-      "git add build/*"
+      "npm run build"
     ]
   },
   "devDependencies": {

--- a/scripts/experience_test.py
+++ b/scripts/experience_test.py
@@ -29,6 +29,12 @@ try:
     src = audio_button.get_attribute("src")
     print("AUDIO SOURCE: ", src)
 
+    # Find and select Allison V3
+    drop_down = driver.find_element_by_xpath("//button[@id='downshift-0-toggle-button']")
+    drop_down.click()
+    drop_down_element = driver.find_element_by_xpath("//div[contains(text(),'Allison (V3)')]")
+    drop_down_element.click()
+
     # Find button and click it
     synthesize_button = driver.find_element_by_xpath("//button[contains(text(),'Synthesize')]")
     synthesize_button.click()


### PR DESCRIPTION
Disable Husky in CI to prevent helm from failing on containerize (#78)

* Remove git add from lint-staged

As seen here: https://github.com/okonet/lint-staged/issues/775, git add is not needed here any more

* changed npm installing to ci prod

This prevents husky from being installed which is was failing due to not having the .git file in the Docker work dir

* Adjust experience test to select voice manually